### PR TITLE
Remove jail-able bug

### DIFF
--- a/contracts/REXMarket.sol
+++ b/contracts/REXMarket.sol
@@ -828,6 +828,7 @@ abstract contract REXMarket is Ownable, SuperAppBase, Initializable {
         bytes calldata // _ctx
     ) external view virtual override returns (bytes memory _cbdata) {
         _onlyHost();
+        _onlyExpected(_superToken, _agreementClass);
 
         (address _shareholder, int96 _flowRateMain, uint256 _timestamp) = _getShareholderInfo(_agreementData, _superToken);
 
@@ -849,6 +850,7 @@ abstract contract REXMarket is Ownable, SuperAppBase, Initializable {
         bytes calldata _ctx
     ) external virtual override returns (bytes memory _newCtx) {
         _onlyHost();
+        _onlyExpected(_superToken, _agreementClass);
 
         _newCtx = _ctx;
         (address _shareholder, ) = abi.decode(_agreementData, (address, address));

--- a/contracts/REXMarket.sol
+++ b/contracts/REXMarket.sol
@@ -828,7 +828,6 @@ abstract contract REXMarket is Ownable, SuperAppBase, Initializable {
         bytes calldata // _ctx
     ) external view virtual override returns (bytes memory _cbdata) {
         _onlyHost();
-        _onlyExpected(_superToken, _agreementClass);
 
         (address _shareholder, int96 _flowRateMain, uint256 _timestamp) = _getShareholderInfo(_agreementData, _superToken);
 
@@ -850,7 +849,6 @@ abstract contract REXMarket is Ownable, SuperAppBase, Initializable {
         bytes calldata _ctx
     ) external virtual override returns (bytes memory _newCtx) {
         _onlyHost();
-        _onlyExpected(_superToken, _agreementClass);
 
         _newCtx = _ctx;
         (address _shareholder, ) = abi.decode(_agreementData, (address, address));

--- a/contracts/REXTwoWayMarket.sol
+++ b/contracts/REXTwoWayMarket.sol
@@ -232,14 +232,15 @@ contract REXTwoWayMarket is REXMarket {
 
   function beforeAgreementTerminated(
       ISuperToken _superToken,
-      address _agreementClass,
+      address,
       bytes32, //_agreementId,
       bytes calldata _agreementData,
       bytes calldata // _ctx
   ) external view virtual override returns (bytes memory _cbdata) {
       _onlyHost();
-      _onlyExpected(_superToken, _agreementClass);
-
+      if (_superToken != inputTokenA && _superToken != inputTokenB) {
+        return _cbdata;
+      }
       (address _shareholder, int96 _flowRateMain, uint256 _timestamp) = _getShareholderInfo(_agreementData, _superToken);
 
       uint256 _uinvestAmount = _calcUserUninvested(
@@ -255,15 +256,16 @@ contract REXTwoWayMarket is REXMarket {
 
   function afterAgreementTerminated(
       ISuperToken _superToken,
-      address _agreementClass,
+      address,
       bytes32, //_agreementId,
       bytes calldata _agreementData,
       bytes calldata _cbdata, //_cbdata,
       bytes calldata _ctx
   ) external virtual override returns (bytes memory _newCtx) {
       _onlyHost();
-      _onlyExpected(_superToken, _agreementClass);
-
+      if (_superToken != inputTokenA && _superToken != inputTokenB) {
+        return _ctx;
+      }
       _newCtx = _ctx;
       (address _shareholder, ) = abi.decode(_agreementData, (address, address));
       (uint256 _uninvestAmount, int96 _beforeFlowRate ) = abi.decode(_cbdata, (uint256, int96));


### PR DESCRIPTION
# Jail-able Bug

Superfluid protocol automatically jails an application when a `beforeAgreementTerminated` or `afterAgreementTerminated` callback reverts.

While the `_onlyHost` check is a valid check for the agreement termination callbacks, the `_onlyExpected(token, agreementClass)` was the source of the bug.

The `_onlyExpected` function requires that if the agreement is a CFA, the token must be `market.inputToken`. The function is defined in the RexMarket contract [here](https://github.com/Fluid-X/ricochet-protocol/blob/b8b3bf8a205dd0c0ec274f05c1253c6d22b31872/contracts/REXMarket.sol#L679).

 However, in the RexTwoWayMarket, the `market.inputToken` is set to the `inputTokenA`, or USDCx in this instance. This happens [here](https://github.com/Fluid-X/ricochet-protocol/blob/b8b3bf8a205dd0c0ec274f05c1253c6d22b31872/contracts/REXTwoWayMarket.sol#L54).
 
 Since the agreement termination callbacks use `_onlyExpected` calls with the token involved in the termination, in our case, WBTCx, this reverts.
 
 This can be reproduced by closing a stream of `inputTokenB` on any RexTwoWayMarket.