### PR TITLE
update oracle to tellorFlex and mesosphere medianizer

### DIFF
--- a/contracts/REXMarket.sol
+++ b/contracts/REXMarket.sol
@@ -350,14 +350,8 @@ abstract contract REXMarket is Ownable, SuperAppBase, Initializable {
             uint256 _timestampRetrieved
         )
     {
-        uint256 _count = oracle.getNewValueCountbyRequestId(_requestId);
-        _timestampRetrieved = oracle.getTimestampbyRequestIDandIndex(
-            _requestId,
-            _count - 1
-        );
-        _value = oracle.retrieveData(_requestId, _timestampRetrieved);
-
-        if (_value > 0) return (true, _value, _timestampRetrieved);
+        (_value, uint256 _quantity) = oracle.getMedian(bytes32(_requestId), block.timestamp, 60, 10);
+        if (_quantity > 0) return (true, _value, block.timestamp - 30);
         return (false, 0, _timestampRetrieved);
     }
 

--- a/contracts/tellor/ITellor.sol
+++ b/contracts/tellor/ITellor.sol
@@ -542,4 +542,20 @@ interface ITellor {
      * @return uint total supply
      */
     function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Gets median of oracle values within a given time interval
+     * @param _queryId is the id of the desired data
+     * @param _timestamp is the highest timestamp in the time interval
+     * @param _timeLimit is the length (seconds) of the time interval
+     * @param _maxValueCount is the max number of values used to calculate a median
+     * @return uint256 the median value
+     * @return uint256 the quantity of values used to determine the median
+     */
+    function getMedian(
+        bytes32 _queryId,
+        uint256 _timestamp,
+        uint256 _timeLimit,
+        uint256 _maxValueCount
+    ) public view returns (uint256, uint256);
 }


### PR DESCRIPTION
This is a way to update the oracle to use TellorFlex. You'll use the new Mesosphere address as the oracle address, which retrieves multiple data points from flex, computes the median, and forwards the median (and the number of values used to compute the median) to the caller. I was having trouble compiling the contracts due to some openzeppelin/superfluid dependency errors.