### PR TITLE
[BUG] Fix swap method for ETH>>USDC market on Optimism

### DIFF
--- a/contracts/REXUniswapV3Market.sol
+++ b/contracts/REXUniswapV3Market.sol
@@ -450,7 +450,12 @@ contract REXUniswapV3Market is
 
         // Downgrade if this is not a supertoken
         if (underlyingInputToken != address(inputToken)) {
-            inputToken.downgrade(inputToken.balanceOf(address(this)));
+            try inputToken.downgrade(inputToken.balanceOf(address(this))) {} catch {
+                
+                ISETHCustom(address(inputToken)).downgradeToETH(
+                    inputToken.balanceOf(address(this))
+                );
+            }
         }
 
         // Calculate the amount of tokens

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,10 +915,10 @@
     mcl-wasm "^0.7.1"
     rustbn.js "~0.2.0"
 
-"@nomicfoundation/solidity-analyzer-win32-x64-msvc@0.1.0":
+"@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0":
   version "0.1.0"
-  resolved "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.0.tgz"
-  integrity sha512-xCuybjY0sLJQnJhupiFAXaek2EqF0AP0eBjgzaalPXSNvCEN6ZYHvUzdA50ENDVeSYFXcUsYf3+FsD3XKaeptA==
+  resolved "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz"
+  integrity sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==
 
 "@nomicfoundation/solidity-analyzer@^0.1.0":
   version "0.1.0"
@@ -6430,6 +6430,16 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fsevents@~2.1.1:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1, function-bind@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
### Description
The swap method for the ETH>>USDC market is currently not working on Optimism. This PR adds a try-catch block to the swap method to check if the downgrade method is available, which should fix the issue.